### PR TITLE
Update manifest.json - minimum pymodbus version instead of fixed version

### DIFF
--- a/custom_components/sax_battery/sensor.py
+++ b/custom_components/sax_battery/sensor.py
@@ -152,7 +152,7 @@ class SAXBatterySensor(SensorEntity):
         return True
 
     def convertToSignedValue(self ,value: int, scale: int) -> int:
-        """Some values are not returned in a properly signed form by the battery. Negative values appear as very high positive numbers"""
+        """Transform values in signed form as negative values appear as very high positive numbers."""
         max_value = 65536 * scale # for int16 values (2^16 = 65536)
         if (value > max_value / 2):
             return value - max_value # value is actually negative


### PR DESCRIPTION
I had problems updating Homeassistant, because another extension was requiring pymodbus 3.9 and both dependencies where mutually exclusive.
Since this extension seems to run fine with higher versions of pymodbus maybe we can change this to a minimum instead of a fixed version requirement?