### PR TITLE
update bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
+title: '[Bug]: <title>'
 labels: ''
 assignees: ''
 
@@ -12,10 +12,12 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+<!--
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
+-->
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
@@ -23,16 +25,16 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+**Home assistant server (please complete the following information):**
+<!-- this information is available in HA->Settings->About -->
+- OS version: [e.g. 16.2]
+- Core version: [e.g. 2025.9.1]
+- Front end version: [e.g. 20250903.3]
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+** SAX power battery
+
+- Model: [7.7 or 5.8 kWh]
+- Number of batteries: [1..3]
 
 **Additional context**
-Add any other context about the problem here.
+Add any other context about the problem here e.g. errors or warning messages from home-assistant.log


### PR DESCRIPTION
This pull request updates the bug report issue template to make it more specific and helpful for users reporting issues related to the Home Assistant server and SAX power battery. The main improvements include clarifying the title format, providing more targeted instructions for reproducing bugs, and collecting more relevant system information.

Template improvements:

* Updated the default issue title to include a `[Bug]:` prefix for better clarity and consistency.
* Added HTML comments to guide users on how to fill out the "Steps to reproduce" section, making it clearer that these are example steps.

System information collection:

* Replaced generic desktop and smartphone fields with specific prompts for Home Assistant server details (OS version, Core version, Front end version) and SAX power battery information (model and number of batteries), ensuring more relevant data is collected for troubleshooting.
* Updated the "Additional context" section to encourage users to include error or warning messages from `home-assistant.log` for better debugging.